### PR TITLE
Retrieve the server port number, the debug logging enabler value, and the routes data store location from the app settings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #
 # .gitignore
 # =============================================================================
-# Urban bus routing microservice prototype (LFE/OTP port). Version 0.0.9
+# Urban bus routing microservice prototype (LFE/OTP port). Version 0.0.10
 # =============================================================================
 # An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile
 # =============================================================================
-# Urban bus routing microservice prototype (LFE/OTP port). Version 0.0.9
+# Urban bus routing microservice prototype (LFE/OTP port). Version 0.0.10
 # =============================================================================
 # An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ $ rebar3 tree
 ===> Fetching pc v1.14.0
 ===> Analyzing applications...
 ...
-└─ bus─0.0.9 (project app)
+└─ bus─0.0.10 (project app)
    └─ syslog─1.1.0 (hex package)
 ```
 

--- a/apps/bus/src/bus-app.lfe
+++ b/apps/bus/src/bus-app.lfe
@@ -34,9 +34,20 @@
     "The application entry point callback.
      Creates the supervision tree by starting the top supervisor."
 
+    ; Getting the application settings.
+    (let ((settings (aux:-get-settings)))
+
+    (let ((server-port       (element 1 settings)))
+    (let ((debug-log-enabled (element 2 settings)))
+    (let ((datastore         (element 3 settings)))
+
+    (logger:debug (integer_to_list server-port))
+    (logger:debug (atom_to_list debug-log-enabled))
+    (logger:debug datastore)))))
+
     (let ((app-name (atom_to_list (element 2 (application:get_application)))))
 
-    (logger:info app-name)
+    (logger:debug app-name)
 
     ; Opening the system logger.
     ; Calling <syslog.h> openlog(NULL, LOG_CONS | LOG_PID, LOG_DAEMON);

--- a/apps/bus/src/bus-app.lfe
+++ b/apps/bus/src/bus-app.lfe
@@ -1,7 +1,7 @@
 ;
 ; apps/bus/src/bus-app.lfe
 ; =============================================================================
-; Urban bus routing microservice prototype (LFE/OTP port). Version 0.0.9
+; Urban bus routing microservice prototype (LFE/OTP port). Version 0.0.10
 ; =============================================================================
 ; An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 ; as a microservice, implementing a simple urban bus routing prototype.
@@ -12,7 +12,7 @@
 ;
 
 #| ----------------------------------------------------------------------------
- | @version 0.0.9
+ | @version 0.0.10
  | @since   0.0.1
  |#
 (defmodule bus-app

--- a/apps/bus/src/bus-helper.lfe
+++ b/apps/bus/src/bus-helper.lfe
@@ -86,36 +86,36 @@
         ('true 'false))))
 
     ; Retrieving the path and filename of the routes data store ---------------
-    (let ((datastore-path-prefix- (application:get_env 'routes-datastore-path-prefix)))
-    (let ((datastore-path-prefix  (cond ((=/= datastore-path-prefix- 'undefined)
-        (let ((datastore-path-prefix-0 (element 2 datastore-path-prefix-)))
-        (let ((datastore-path-prefix-1 (string:is_empty datastore-path-prefix-0)))
-        (if  (not datastore-path-prefix-1) datastore-path-prefix-0
+    (let ((ds-path-prefix-(application:get_env 'routes-datastore-path-prefix)))
+    (let ((ds-path-prefix (cond ((=/= ds-path-prefix- 'undefined)
+        (let ((ds-path-prefix-0 (element 2 ds-path-prefix-)))
+        (let ((ds-path-prefix-1 (string:is_empty ds-path-prefix-0)))
+        (if  (not ds-path-prefix-1) ds-path-prefix-0
                (SAMPLE-ROUTES-PATH-PREFIX)))))
         ('true (SAMPLE-ROUTES-PATH-PREFIX)))))
 
-    (let ((datastore-path-dir- (application:get_env 'routes-datastore-path-dir)))
-    (let ((datastore-path-dir  (cond ((=/= datastore-path-dir- 'undefined)
-        (let ((datastore-path-dir-0 (element 2 datastore-path-dir-)))
-        (let ((datastore-path-dir-1 (string:is_empty datastore-path-dir-0)))
-        (if  (not datastore-path-dir-1) datastore-path-dir-0
+    (let ((ds-path-dir-(application:get_env 'routes-datastore-path-dir)))
+    (let ((ds-path-dir (cond ((=/= ds-path-dir- 'undefined)
+        (let ((ds-path-dir-0 (element 2 ds-path-dir-)))
+        (let ((ds-path-dir-1 (string:is_empty ds-path-dir-0)))
+        (if  (not ds-path-dir-1) ds-path-dir-0
                (SAMPLE-ROUTES-PATH-DIR)))))
         ('true (SAMPLE-ROUTES-PATH-DIR)))))
 
-    (let ((datastore-filename- (application:get_env 'routes-datastore-filename)))
-    (let ((datastore-filename  (cond ((=/= datastore-filename- 'undefined)
-        (let ((datastore-filename-0 (element 2 datastore-filename-)))
-        (let ((datastore-filename-1 (string:is_empty datastore-filename-0)))
-        (if  (not datastore-filename-1) datastore-filename-0
+    (let ((ds-filename-(application:get_env 'routes-datastore-filename)))
+    (let ((ds-filename (cond ((=/= ds-filename- 'undefined)
+        (let ((ds-filename-0 (element 2 ds-filename-)))
+        (let ((ds-filename-1 (string:is_empty ds-filename-0)))
+        (if  (not ds-filename-1) ds-filename-0
                (SAMPLE-ROUTES-FILENAME)))))
         ('true (SAMPLE-ROUTES-FILENAME)))))
 
     `#(
         ,server-port
         ,debug-log-enabled ; <== "true" or "false".
-    ,(++ datastore-path-prefix
-         datastore-path-dir
-         datastore-filename)
+    ,(++ ds-path-prefix
+         ds-path-dir
+         ds-filename)
     )))))))))))
 )
 

--- a/apps/bus/src/bus-helper.lfe
+++ b/apps/bus/src/bus-helper.lfe
@@ -24,9 +24,30 @@
     (export (-get-settings 0))
 )
 
+; Common error messages.
+(defmacro ERR-PORT-VALID-MUST-BE-POSITIVE-INT ()
+      (++ "Valid server port must be a positive integer value, "
+          "in the range 1024 .. 49151. The default value of 8080 "
+          "will be used instead."))
+
 ; Common notification messages.
 (defmacro MSG-SERVER-STARTED () "Server started")
 (defmacro MSG-SERVER-STOPPED () "Server stopped")
+
+#| ----------------------------------------------------------------------------
+ | The minimum port number allowed.
+ |#
+(defmacro MIN_PORT () 1024)
+
+#| ----------------------------------------------------------------------------
+ | The maximum port number allowed.
+ |#
+(defmacro MAX_PORT () 49151)
+
+#| ----------------------------------------------------------------------------
+ | The default server port number.
+ |#
+(defmacro DEF_PORT () 8080)
 
 ; -----------------------------------------------------------------------------
 ; Helper function. Used to get the application settings.
@@ -34,7 +55,23 @@
 ; Returns: The tuple containing values of individual settings.
 (defun -get-settings ()
     ; Retrieving the port number used to run the server -----------------------
-    (let ((server-port 8765))
+    (let ((server-port- (application:get_env 'server-port)))
+
+    (let ((server-port  (cond ((=/= server-port- 'undefined)
+        (let ((server-port-- (element 2 server-port-)))
+
+        (cond ((and (>= server-port-- (MIN_PORT))
+                    (=< server-port-- (MAX_PORT))) server-port--)
+        ('true
+            (logger:error (ERR-PORT-VALID-MUST-BE-POSITIVE-INT))
+
+            (DEF_PORT)
+        ))))
+    ('true
+        (logger:error (ERR-PORT-VALID-MUST-BE-POSITIVE-INT))
+
+        (DEF_PORT)
+    ))))
 
     ; Identifying, whether debug logging is enabled ---------------------------
     (let ((debug-log-enabled 'true))
@@ -50,7 +87,7 @@
     ,(++ datastore-path-prefix
          datastore-path-dir
          datastore-filename)
-    ))))))
+    )))))))
 )
 
 ; vim:set nu et ts=4 sw=4:

--- a/apps/bus/src/bus-helper.lfe
+++ b/apps/bus/src/bus-helper.lfe
@@ -1,7 +1,7 @@
 ;
 ; apps/bus/src/bus-helper.lfe
 ; =============================================================================
-; Urban bus routing microservice prototype (LFE/OTP port). Version 0.0.9
+; Urban bus routing microservice prototype (LFE/OTP port). Version 0.0.10
 ; =============================================================================
 ; An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 ; as a microservice, implementing a simple urban bus routing prototype.
@@ -12,7 +12,7 @@
 ;
 
 #| ----------------------------------------------------------------------------
- | @version 0.0.9
+ | @version 0.0.10
  | @since   0.0.5
  |#
 (defmodule aux

--- a/apps/bus/src/bus-helper.lfe
+++ b/apps/bus/src/bus-helper.lfe
@@ -20,10 +20,37 @@
 
     (export-macro MSG-SERVER-STARTED
                   MSG-SERVER-STOPPED)
+
+    (export (-get-settings 0))
 )
 
 ; Common notification messages.
 (defmacro MSG-SERVER-STARTED () "Server started")
 (defmacro MSG-SERVER-STOPPED () "Server stopped")
+
+; -----------------------------------------------------------------------------
+; Helper function. Used to get the application settings.
+;
+; Returns: The tuple containing values of individual settings.
+(defun -get-settings ()
+    ; Retrieving the port number used to run the server -----------------------
+    (let ((server-port 8765))
+
+    ; Identifying, whether debug logging is enabled ---------------------------
+    (let ((debug-log-enabled 'true))
+
+    ; Retrieving the path and filename of the routes data store ---------------
+    (let ((datastore-path-prefix "x"))
+    (let ((datastore-path-dir    "y"))
+    (let ((datastore-filename    "z"))
+
+    `#(
+        ,server-port
+        ,debug-log-enabled ; <== "true" or "false".
+    ,(++ datastore-path-prefix
+         datastore-path-dir
+         datastore-filename)
+    ))))))
+)
 
 ; vim:set nu et ts=4 sw=4:

--- a/apps/bus/src/bus-helper.lfe
+++ b/apps/bus/src/bus-helper.lfe
@@ -37,17 +37,22 @@
 #| ----------------------------------------------------------------------------
  | The minimum port number allowed.
  |#
-(defmacro MIN_PORT () 1024)
+(defmacro MIN-PORT () 1024)
 
 #| ----------------------------------------------------------------------------
  | The maximum port number allowed.
  |#
-(defmacro MAX_PORT () 49151)
+(defmacro MAX-PORT () 49151)
 
 #| ----------------------------------------------------------------------------
  | The default server port number.
  |#
-(defmacro DEF_PORT () 8080)
+(defmacro DEF-PORT () 8080)
+
+; The path and filename of the sample routes data store.
+(defmacro SAMPLE-ROUTES-PATH-PREFIX () "./"        )
+(defmacro SAMPLE-ROUTES-PATH-DIR    () "data/"     )
+(defmacro SAMPLE-ROUTES-FILENAME    () "routes.txt")
 
 ; -----------------------------------------------------------------------------
 ; Helper function. Used to get the application settings.
@@ -60,26 +65,50 @@
     (let ((server-port  (cond ((=/= server-port- 'undefined)
         (let ((server-port-- (element 2 server-port-)))
 
-        (cond ((and (>= server-port-- (MIN_PORT))
-                    (=< server-port-- (MAX_PORT))) server-port--)
+        (cond ((and (>= server-port-- (MIN-PORT))
+                    (=< server-port-- (MAX-PORT))) server-port--)
         ('true
             (logger:error (ERR-PORT-VALID-MUST-BE-POSITIVE-INT))
 
-            (DEF_PORT)
+            (DEF-PORT)
         ))))
     ('true
         (logger:error (ERR-PORT-VALID-MUST-BE-POSITIVE-INT))
 
-        (DEF_PORT)
+        (DEF-PORT)
     ))))
 
     ; Identifying, whether debug logging is enabled ---------------------------
-    (let ((debug-log-enabled 'true))
+    (let ((debug-log-enabled- (application:get_env 'logger-debug-enabled)))
+
+    (let ((debug-log-enabled  (cond ((=/= debug-log-enabled- 'undefined)
+        (if (=:= (element 2 debug-log-enabled-) 'yes) 'true 'false))
+        ('true 'false))))
 
     ; Retrieving the path and filename of the routes data store ---------------
-    (let ((datastore-path-prefix "x"))
-    (let ((datastore-path-dir    "y"))
-    (let ((datastore-filename    "z"))
+    (let ((datastore-path-prefix- (application:get_env 'routes-datastore-path-prefix)))
+    (let ((datastore-path-prefix  (cond ((=/= datastore-path-prefix- 'undefined)
+        (let ((datastore-path-prefix-0 (element 2 datastore-path-prefix-)))
+        (let ((datastore-path-prefix-1 (string:is_empty datastore-path-prefix-0)))
+        (if  (not datastore-path-prefix-1) datastore-path-prefix-0
+               (SAMPLE-ROUTES-PATH-PREFIX)))))
+        ('true (SAMPLE-ROUTES-PATH-PREFIX)))))
+
+    (let ((datastore-path-dir- (application:get_env 'routes-datastore-path-dir)))
+    (let ((datastore-path-dir  (cond ((=/= datastore-path-dir- 'undefined)
+        (let ((datastore-path-dir-0 (element 2 datastore-path-dir-)))
+        (let ((datastore-path-dir-1 (string:is_empty datastore-path-dir-0)))
+        (if  (not datastore-path-dir-1) datastore-path-dir-0
+               (SAMPLE-ROUTES-PATH-DIR)))))
+        ('true (SAMPLE-ROUTES-PATH-DIR)))))
+
+    (let ((datastore-filename- (application:get_env 'routes-datastore-filename)))
+    (let ((datastore-filename  (cond ((=/= datastore-filename- 'undefined)
+        (let ((datastore-filename-0 (element 2 datastore-filename-)))
+        (let ((datastore-filename-1 (string:is_empty datastore-filename-0)))
+        (if  (not datastore-filename-1) datastore-filename-0
+               (SAMPLE-ROUTES-FILENAME)))))
+        ('true (SAMPLE-ROUTES-FILENAME)))))
 
     `#(
         ,server-port
@@ -87,7 +116,7 @@
     ,(++ datastore-path-prefix
          datastore-path-dir
          datastore-filename)
-    )))))))
+    )))))))))))
 )
 
 ; vim:set nu et ts=4 sw=4:

--- a/apps/bus/src/bus-sup.lfe
+++ b/apps/bus/src/bus-sup.lfe
@@ -1,7 +1,7 @@
 ;
 ; apps/bus/src/bus-sup.lfe
 ; =============================================================================
-; Urban bus routing microservice prototype (LFE/OTP port). Version 0.0.9
+; Urban bus routing microservice prototype (LFE/OTP port). Version 0.0.10
 ; =============================================================================
 ; An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 ; as a microservice, implementing a simple urban bus routing prototype.
@@ -12,7 +12,7 @@
 ;
 
 #| ----------------------------------------------------------------------------
- | @version 0.0.9
+ | @version 0.0.10
  | @since   0.0.1
  |#
 (defmodule bus-sup

--- a/apps/bus/src/bus.app.src
+++ b/apps/bus/src/bus.app.src
@@ -1,7 +1,7 @@
 %
 % apps/bus/src/bus.app.src
 % =============================================================================
-% Urban bus routing microservice prototype (LFE/OTP port). Version 0.0.9
+% Urban bus routing microservice prototype (LFE/OTP port). Version 0.0.10
 % =============================================================================
 % An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 % as a microservice, implementing a simple urban bus routing prototype.
@@ -13,7 +13,7 @@
 
 {application, bus, [
     {description,  "Urban bus routing microservice prototype."},
-    {vsn,          "0.0.9"},
+    {vsn,          "0.0.10"},
     {licenses,     ["MIT License"]},
     {links,        []},
     {modules,      []},

--- a/apps/bus/src/bus.app.src
+++ b/apps/bus/src/bus.app.src
@@ -23,7 +23,10 @@
         stdlib,
         syslog
     ]},
-    {mod, {'bus-app', []}}
+    {mod, {'bus-app', []}},
+    {env, [
+        {'server-port', 1234}
+    ]}
 ]}.
 
 % vim:set nu et ts=4 sw=4:

--- a/apps/bus/src/bus.app.src
+++ b/apps/bus/src/bus.app.src
@@ -25,7 +25,7 @@
     ]},
     {mod, {'bus-app', []}},
     {env, [
-        {'server-port', 1234}
+        {'server-port', 8765}
     ]}
 ]}.
 

--- a/apps/bus/src/bus.app.src
+++ b/apps/bus/src/bus.app.src
@@ -25,7 +25,14 @@
     ]},
     {mod, {'bus-app', []}},
     {env, [
-        {'server-port', 8765}
+        {'server-port', 8765},
+
+        % Uncomment this setting to enable debug logging.
+%       {'logger-debug-enabled', yes},
+
+        {'routes-datastore-path-prefix', "./"        },
+        {'routes-datastore-path-dir',    "data/"     },
+        {'routes-datastore-filename',    "routes.txt"}
     ]}
 ]}.
 

--- a/config/sys.config
+++ b/config/sys.config
@@ -1,7 +1,7 @@
 %
 % config/sys.config
 % =============================================================================
-% Urban bus routing microservice prototype (LFE/OTP port). Version 0.0.9
+% Urban bus routing microservice prototype (LFE/OTP port). Version 0.0.10
 % =============================================================================
 % An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 % as a microservice, implementing a simple urban bus routing prototype.

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 %
 % rebar.config
 % =============================================================================
-% Urban bus routing microservice prototype (LFE/OTP port). Version 0.0.9
+% Urban bus routing microservice prototype (LFE/OTP port). Version 0.0.10
 % =============================================================================
 % An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 % as a microservice, implementing a simple urban bus routing prototype.
@@ -13,7 +13,7 @@
 
 {relx, [
     {release, {
-        bus, "0.0.9"
+        bus, "0.0.10"
     }, [
         bus
     ]},


### PR DESCRIPTION
- Introducing a _helper function_ that is used to get the application settings.
- Getting application settings by calling a dedicated _helper function_ for that, and logging their values for debug purposes.
- Adding the server port number to the app settings.
- Retrieving the server port number from the app settings.
- Seting the effective (conformed) server port number in the app settings.
- Adding the debug logging enabler and the routes data store location to the app settings.
- Retrieving the debug logging enabler value and the routes data store location from the app settings.
- Bumping version number to **0.0.10**.