### PR TITLE
Identify, whether a particular interval between two bus stop points is direct.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #
 # .gitignore
 # =============================================================================
-# Urban bus routing microservice prototype (LFE/OTP port). Version 0.1.5
+# Urban bus routing microservice prototype (LFE/OTP port). Version 0.2.2
 # =============================================================================
 # An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile
 # =============================================================================
-# Urban bus routing microservice prototype (LFE/OTP port). Version 0.1.5
+# Urban bus routing microservice prototype (LFE/OTP port). Version 0.2.2
 # =============================================================================
 # An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ $ rebar3 tree
 ===> Fetching pc v1.14.0
 ===> Analyzing applications...
 ...
-└─ bus─0.1.5 (project app)
+└─ bus─0.2.2 (project app)
    ├─ cowboy─2.10.0 (hex package)
    │  ├─ cowlib─2.12.1 (hex package)
    │  └─ ranch─1.8.0 (hex package)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ One may consider this project has to be suitable for a wide variety of applied a
 
 ---
 
+## Table of Contents
+
+* **[Building](#building)**
+* **[Running](#running)**
+* **[Consuming](#consuming)**
+  * **[Logging](#logging)**
+  * **[Error handling](#error-handling)**
+
 ## Building
 
 The microservice is known to be built and run successfully under **Ubuntu Server (Ubuntu 22.04.2 LTS x86-64)**. Install the necessary dependencies (`erlang-nox`, `erlang-dev`, `rebar3`, `make`, `docker.io`):
@@ -153,5 +161,72 @@ $ ./_build/default/rel/bus/bin/bus daemon; echo $?
 ```
 
 The `daemon_attach` command then allows connecting to the microservice to make interactions with them. But the latter is not required at all regarding the true purpose of the microservice. And it can be stopped again with the `stop` command in the same terminal session.
+
+## Consuming
+
+All the routes are contained in a so-called **routes data store**. It is located in the `data/` directory. The default filename for it is `routes.txt`, but it can be specified explicitly (if intended to use another one) in the `apps/bus/src/bus.app.src` file.
+
+**Identify**, whether there is a direct route between two bus stops with IDs given in the **HTTP GET** request, searching for them against the underlying **routes data store**:
+
+HTTP request param | Sample value | Another sample value | Yet another sample value
+------------------ | ------------ | -------------------- | ------------------------
+`from`             | `4838`       | `82`                 | `2147483647`
+`to`               | `524987`     | `35390`              | `1`
+
+The direct route is found:
+
+```
+$ curl 'http://localhost:8765/route/direct?from=4838&to=524987'
+{"direct":true,"from":4838,"to":524987}
+```
+
+The direct route is not found:
+
+```
+$ curl 'http://localhost:8765/route/direct?from=82&to=35390'
+{"direct":false,"from":82,"to":35390}
+```
+
+### Logging
+
+The microservice has the ability to log messages to a logfile and to the Unix syslog facility. Logs can be seen and analyzed by `tail`ing the `_build/default/rel/bus/log/bus.log` logfile:
+
+```
+$ tail -f _build/default/rel/bus/log/bus.log
+...
+[2023-07-31|01:20:11.256584+03:00][info]  Server started on port 8765
+[2023-07-31|01:20:11.257210+03:00][info]  Application: bus. Started at: bus@localhost.
+[2023-07-31|01:21:25.207825+03:00][debug]  from=4838 | to=524987
+[2023-07-31|01:21:50.882326+03:00][debug]  from=82 | to=35390
+[2023-07-31|01:25:35.616223+03:00][info]  Server stopped
+```
+
+Messages registered by the Unix system logger can be seen and analyzed using the `journalctl` utility:
+
+```
+$ journalctl -f
+...
+Jul 31 01:20:10 <hostname> bus[<pid>]: Starting up
+Jul 31 01:20:11 <hostname> bus[<pid>]: Server started on port 8765
+Jul 31 01:21:25 <hostname> bus[<pid>]: from=4838 | to=524987
+Jul 31 01:21:50 <hostname> bus[<pid>]: from=82 | to=35390
+Jul 31 01:25:35 <hostname> bus[<pid>]: Server stopped
+```
+
+### Error handling
+
+When the query string passed in a request, contains inappropriate input, or the URI endpoint doesn't contain anything else at all after its path, the microservice will respond with the **HTTP 400 Bad Request** status code, including a specific response body in JSON representation, like the following:
+
+```
+$ curl 'http://localhost:8765/route/direct?from=qwerty4838&to=-i-.;--089asdf../nj524987'
+{"error":"Request parameters must take positive integer values, in the range 1 .. 2,147,483,647. Please check your inputs."}
+```
+
+Or even simpler:
+
+```
+$ curl http://localhost:8765/route/direct
+{"error":"Request parameters must take positive integer values, in the range 1 .. 2,147,483,647. Please check your inputs."}
+```
 
 **TBD** :dvd:

--- a/apps/bus/src/bus-app.lfe
+++ b/apps/bus/src/bus-app.lfe
@@ -1,7 +1,7 @@
 ;
 ; apps/bus/src/bus-app.lfe
 ; =============================================================================
-; Urban bus routing microservice prototype (LFE/OTP port). Version 0.1.5
+; Urban bus routing microservice prototype (LFE/OTP port). Version 0.2.2
 ; =============================================================================
 ; An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 ; as a microservice, implementing a simple urban bus routing prototype.
@@ -12,7 +12,7 @@
 ;
 
 #| ----------------------------------------------------------------------------
- | @version 0.1.5
+ | @version 0.2.2
  | @since   0.0.1
  |#
 (defmodule bus-app

--- a/apps/bus/src/bus-controller.lfe
+++ b/apps/bus/src/bus-controller.lfe
@@ -1,7 +1,7 @@
 ;
 ; apps/bus/src/bus-controller.lfe
 ; =============================================================================
-; Urban bus routing microservice prototype (LFE/OTP port). Version 0.1.5
+; Urban bus routing microservice prototype (LFE/OTP port). Version 0.2.2
 ; =============================================================================
 ; An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 ; as a microservice, implementing a simple urban bus routing prototype.
@@ -12,7 +12,7 @@
 ;
 
 #| ----------------------------------------------------------------------------
- | @version 0.1.5
+ | @version 0.2.2
  | @since   0.0.12
  |#
 (defmodule bus-controller

--- a/apps/bus/src/bus-handler.lfe
+++ b/apps/bus/src/bus-handler.lfe
@@ -80,6 +80,60 @@
 (defun to-json (req state)
     "The so-called `ProvideCallback', used to return the response body."
 
+    (let ((`#M(
+        debug-log-enabled ,debug-log-enabled
+        routes-list       ,routes-list
+        syslog            ,syslog
+    ) state))
+
+    (logger:debug (atom_to_list debug-log-enabled))
+;   (logger:debug routes-list)
+    (logger:debug (port_to_list syslog))
+    (logger:debug "----------------")
+
+    ; -------------------------------------------------------------------------
+    ; --- Parsing and validating request params - Begin -----------------------
+    ; -------------------------------------------------------------------------
+    (let ((`#M(from ,from- to ,to-) (cowboy_req:match_qs `(
+        #(from () ,(aux:ZERO))
+        #(to   () ,(aux:ZERO))
+    ) req)))
+
+    (logger:debug from-)
+    (logger:debug to-  )
+    (logger:debug "----------------")
+
+    (let ((from-- (if (is_boolean from-) (aux:ZERO) from-)))
+    (let ((to--   (if (is_boolean to-  ) (aux:ZERO) to-  )))
+
+    (logger:debug from--)
+    (logger:debug to--  )
+    (logger:debug "----------------")
+
+    (cond ((not debug-log-enabled)
+        (let ((FROM--- (binary:bin_to_list (aux:FROM))))
+        (let ((from--- (binary:bin_to_list from--    )))
+        (let ((TO---   (binary:bin_to_list (aux:TO  ))))
+        (let ((to---   (binary:bin_to_list to--      )))
+
+        (logger:debug                     (++ FROM--- (aux:EQUALS) from---
+            (aux:SPACE)(aux:V-BAR)(aux:SPACE) TO---   (aux:EQUALS) to---))
+
+        (syslog:log syslog 'debug         (++ FROM--- (aux:EQUALS) from---
+            (aux:SPACE)(aux:V-BAR)(aux:SPACE) TO---   (aux:EQUALS) to---)))))))
+    ('true 'false))
+
+;   (let ((from (try (binary_to_integer from--) (catch (error:badarg) 0))))
+;   (let ((to   (try (binary_to_integer to--  ) (catch (error:badarg) 0))))
+
+;   (logger:debug from)
+;   (logger:debug to  )
+    (logger:debug "----------------")
+    ))));))
+    ; -------------------------------------------------------------------------
+    ; --- Parsing and validating request params - End -------------------------
+    ; -------------------------------------------------------------------------
+
     (let ((from 1))
     (let ((to 100))
     (let ((direct 'false))

--- a/apps/bus/src/bus-handler.lfe
+++ b/apps/bus/src/bus-handler.lfe
@@ -1,7 +1,7 @@
 ;
 ; apps/bus/src/bus-handler.lfe
 ; =============================================================================
-; Urban bus routing microservice prototype (LFE/OTP port). Version 0.1.5
+; Urban bus routing microservice prototype (LFE/OTP port). Version 0.2.2
 ; =============================================================================
 ; An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 ; as a microservice, implementing a simple urban bus routing prototype.
@@ -12,7 +12,7 @@
 ;
 
 #| ----------------------------------------------------------------------------
- | @version 0.1.5
+ | @version 0.2.2
  | @since   0.0.13
  |#
 (defmodule bus-handler

--- a/apps/bus/src/bus-handler.lfe
+++ b/apps/bus/src/bus-handler.lfe
@@ -131,7 +131,7 @@
         ; there, including the content-type, which is set correctly.
         (cowboy_req:reply (aux:HTTP-400-BAD-REQ) (cowboy_req:set_resp_body
         (jsx:encode `#M(
-            error ,(aux:ERR-REQ-PARAMS-MUST-BE-POSITIVE-INTS)
+            error ,(list_to_binary (aux:ERR-REQ-PARAMS-MUST-BE-POSITIVE-INTS))
         )) req)))
     ('true
         ; Performing the routes processing to find out the direct route.

--- a/apps/bus/src/bus-handler.lfe
+++ b/apps/bus/src/bus-handler.lfe
@@ -171,7 +171,7 @@
 
             (let ((match-from
                 (re:run route (++ (aux:SEQ1-REGEX) from (aux:SEQ2-REGEX)))))
-            (cond ((=:= (element 1 match-from) 'match)
+            (if (is_tuple match-from)(cond ((=:= (element 1 match-from) 'match)
                 ; Pinning in the starting bus stop point, if it's found.
                 ; Next, searching for the ending bus stop point
                 ; on the current route, beginning at the pinned point.
@@ -185,8 +185,9 @@
 
                 (let ((match-to (re:run route-from
                     (++ (aux:SEQ1-REGEX) to (aux:SEQ2-REGEX)))))
-                (if (=:= (element 1 match-to) 'match) (throw 'true) 'false))))
-            ('true 'false)))
+                (if (is_tuple match-to) (if (=:= (element 1 match-to) 'match)
+                    (throw 'true) 'false) 'false))))
+            ('true 'false)) 'false))
 
             (+ i 1)
         ) 1 routes-list) 'false)

--- a/apps/bus/src/bus-handler.lfe
+++ b/apps/bus/src/bus-handler.lfe
@@ -97,7 +97,7 @@
     (let ((from-- (if (is_boolean from-) (aux:ZERO) from-)))
     (let ((to--   (if (is_boolean to-  ) (aux:ZERO) to-  )))
 
-    (cond ((not debug-log-enabled)
+    (cond (debug-log-enabled
         (let ((FROM--- (binary:bin_to_list (aux:FROM))))
         (let ((from--- (binary:bin_to_list from--    )))
         (let ((TO---   (binary:bin_to_list (aux:TO  ))))
@@ -159,7 +159,7 @@
 
     (try (progn
         (lists:foldl (lambda (route i)
-            (if (not debug-log-enabled)
+            (if debug-log-enabled
                 (logger:debug (++ (integer_to_list i)
                     (aux:SPACE)(aux:EQUALS)(aux:SPACE) route))
                 'false)
@@ -173,7 +173,7 @@
                 (let ((route-from
                     (string:slice route (- (string:str route from) 1))))
 
-                (if (not debug-log-enabled)
+                (if debug-log-enabled
                     (logger:debug (++ from
                         (aux:SPACE)(aux:V-BAR)(aux:SPACE) route-from))
                     'false)

--- a/apps/bus/src/bus-handler.lfe
+++ b/apps/bus/src/bus-handler.lfe
@@ -86,8 +86,6 @@
         syslog            ,syslog
     ) state))
 
-    (logger:debug (atom_to_list debug-log-enabled))
-
     ; -------------------------------------------------------------------------
     ; --- Parsing and validating request params - Begin -----------------------
     ; -------------------------------------------------------------------------
@@ -114,9 +112,6 @@
 
     (let ((from (try(binary_to_integer from--) (catch(`#(error badarg ,_)0)))))
     (let ((to   (try(binary_to_integer to--  ) (catch(`#(error badarg ,_)0)))))
-
-    (logger:debug (integer_to_list from))
-    (logger:debug (integer_to_list to  ))
 
     (let ((is-request-malformed (if (or (< from 1) (< to 1)) 'true 'false)))
     ; -------------------------------------------------------------------------

--- a/apps/bus/src/bus-helper.lfe
+++ b/apps/bus/src/bus-helper.lfe
@@ -36,7 +36,9 @@
     (export-macro MSG-SERVER-STARTED
                   MSG-SERVER-STOPPED)
 ; -----------------------------------------------------------------------------
-    (export-macro ROUTE-ID-REGEX)
+    (export-macro ROUTE-ID-REGEX
+                  SEQ1-REGEX
+                  SEQ2-REGEX)
 ; -----------------------------------------------------------------------------
     (export-macro REST-PREFIX
                   REST-DIRECT)
@@ -88,6 +90,18 @@
  | in the routes processing anyhow.
  |#
 (defmacro ROUTE-ID-REGEX () "^\\d+")
+
+#| ----------------------------------------------------------------------------
+ | The regex pattern for the leading part of a bus stops sequence,
+ | before the matching element.
+ |#
+(defmacro SEQ1-REGEX () ".*\\s")
+
+#| ----------------------------------------------------------------------------
+ | The regex pattern for the trailing part of a bus stops sequence,
+ | after the matching element.
+ |#
+(defmacro SEQ2-REGEX () "\\s.*")
 
 #| ----------------------------------------------------------------------------
  | The minimum port number allowed.

--- a/apps/bus/src/bus-helper.lfe
+++ b/apps/bus/src/bus-helper.lfe
@@ -75,8 +75,8 @@
 (defmacro ERR-SERV-UNKNOWN-REASON ()
           "for an unknown reason. Quitting...")
 (defmacro ERR-REQ-PARAMS-MUST-BE-POSITIVE-INTS ()
-         #"Request parameters must take positive integer values, "
-         #"in the range 1 .. 2,147,483,647. Please check your inputs.")
+      (++ "Request parameters must take positive integer values, "
+          "in the range 1 .. 2,147,483,647. Please check your inputs."))
 
 ; Common notification messages.
 (defmacro MSG-SERVER-STARTED () "Server started on port ")

--- a/apps/bus/src/bus-helper.lfe
+++ b/apps/bus/src/bus-helper.lfe
@@ -30,7 +30,8 @@
     (export-macro ERR-DATASTORE-NOT-FOUND
                   ERR-CANNOT-START-SERVER
                   ERR-ADDR-ALREADY-IN-USE
-                  ERR-SERV-UNKNOWN-REASON)
+                  ERR-SERV-UNKNOWN-REASON
+                  ERR-REQ-PARAMS-MUST-BE-POSITIVE-INTS)
 ; -----------------------------------------------------------------------------
     (export-macro MSG-SERVER-STARTED
                   MSG-SERVER-STOPPED)
@@ -44,7 +45,8 @@
                   MIME-SUB-TYPE
                   FROM
                   TO
-                  ZERO)
+                  ZERO
+                  HTTP-400-BAD-REQ)
 ; -----------------------------------------------------------------------------
     (export (-get-settings 0))
 )
@@ -72,6 +74,9 @@
           "due to address requested already in use. Quitting...")
 (defmacro ERR-SERV-UNKNOWN-REASON ()
           "for an unknown reason. Quitting...")
+(defmacro ERR-REQ-PARAMS-MUST-BE-POSITIVE-INTS ()
+         #"Request parameters must take positive integer values, "
+         #"in the range 1 .. 2,147,483,647. Please check your inputs.")
 
 ; Common notification messages.
 (defmacro MSG-SERVER-STARTED () "Server started on port ")
@@ -118,6 +123,9 @@
 
 ; HTTP request parameter default values.
 (defmacro ZERO () #"0")
+
+; HTTP response status codes.
+(defmacro HTTP-400-BAD-REQ () 400)
 
 ; -----------------------------------------------------------------------------
 ; Helper function. Used to get the application settings.

--- a/apps/bus/src/bus-helper.lfe
+++ b/apps/bus/src/bus-helper.lfe
@@ -1,7 +1,7 @@
 ;
 ; apps/bus/src/bus-helper.lfe
 ; =============================================================================
-; Urban bus routing microservice prototype (LFE/OTP port). Version 0.1.5
+; Urban bus routing microservice prototype (LFE/OTP port). Version 0.2.2
 ; =============================================================================
 ; An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 ; as a microservice, implementing a simple urban bus routing prototype.
@@ -12,7 +12,7 @@
 ;
 
 #| ----------------------------------------------------------------------------
- | @version 0.1.5
+ | @version 0.2.2
  | @since   0.0.5
  |#
 (defmodule aux

--- a/apps/bus/src/bus-helper.lfe
+++ b/apps/bus/src/bus-helper.lfe
@@ -22,7 +22,9 @@
                   EXIT-SUCCESS
                   EMPTY-STRING
                   SPACE
+                  V-BAR
                   SLASH
+                  EQUALS
                   NEW-LINE)
 ; -----------------------------------------------------------------------------
     (export-macro ERR-DATASTORE-NOT-FOUND
@@ -39,10 +41,10 @@
                   REST-DIRECT)
 ; -----------------------------------------------------------------------------
     (export-macro MIME-TYPE
-                  MIME-SUB-TYPE)
-; -----------------------------------------------------------------------------
-    (export-macro FROM
-                  TO)
+                  MIME-SUB-TYPE
+                  FROM
+                  TO
+                  ZERO)
 ; -----------------------------------------------------------------------------
     (export (-get-settings 0))
 )
@@ -52,7 +54,9 @@
 (defmacro EXIT-SUCCESS ()    0) ; Successful exit status.
 (defmacro EMPTY-STRING ()   "")
 (defmacro SPACE        ()  " ")
+(defmacro V-BAR        ()  "|")
 (defmacro SLASH        ()  "/")
+(defmacro EQUALS       ()  "=")
 (defmacro NEW-LINE     () "\n")
 
 ; Common error messages.
@@ -111,6 +115,9 @@
 ; HTTP request parameter names.
 (defmacro FROM () #"from")
 (defmacro TO   () #"to"  )
+
+; HTTP request parameter default values.
+(defmacro ZERO () #"0")
 
 ; -----------------------------------------------------------------------------
 ; Helper function. Used to get the application settings.

--- a/apps/bus/src/bus-sup.lfe
+++ b/apps/bus/src/bus-sup.lfe
@@ -1,7 +1,7 @@
 ;
 ; apps/bus/src/bus-sup.lfe
 ; =============================================================================
-; Urban bus routing microservice prototype (LFE/OTP port). Version 0.1.5
+; Urban bus routing microservice prototype (LFE/OTP port). Version 0.2.2
 ; =============================================================================
 ; An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 ; as a microservice, implementing a simple urban bus routing prototype.
@@ -12,7 +12,7 @@
 ;
 
 #| ----------------------------------------------------------------------------
- | @version 0.1.5
+ | @version 0.2.2
  | @since   0.0.1
  |#
 (defmodule bus-sup

--- a/apps/bus/src/bus.app.src
+++ b/apps/bus/src/bus.app.src
@@ -1,7 +1,7 @@
 %
 % apps/bus/src/bus.app.src
 % =============================================================================
-% Urban bus routing microservice prototype (LFE/OTP port). Version 0.1.5
+% Urban bus routing microservice prototype (LFE/OTP port). Version 0.2.2
 % =============================================================================
 % An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 % as a microservice, implementing a simple urban bus routing prototype.
@@ -13,7 +13,7 @@
 
 {application, bus, [
     {description,  "Urban bus routing microservice prototype."},
-    {vsn,          "0.1.5"},
+    {vsn,          "0.2.2"},
     {licenses,     ["MIT License"]},
     {links,        []},
     {modules,      []},

--- a/config/sys.config
+++ b/config/sys.config
@@ -1,7 +1,7 @@
 %
 % config/sys.config
 % =============================================================================
-% Urban bus routing microservice prototype (LFE/OTP port). Version 0.1.5
+% Urban bus routing microservice prototype (LFE/OTP port). Version 0.2.2
 % =============================================================================
 % An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 % as a microservice, implementing a simple urban bus routing prototype.

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 %
 % rebar.config
 % =============================================================================
-% Urban bus routing microservice prototype (LFE/OTP port). Version 0.1.5
+% Urban bus routing microservice prototype (LFE/OTP port). Version 0.2.2
 % =============================================================================
 % An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 % as a microservice, implementing a simple urban bus routing prototype.
@@ -13,7 +13,7 @@
 
 {relx, [
     {release, {
-        bus, "0.1.5"
+        bus, "0.2.2"
     }, [
         bus
     ]},


### PR DESCRIPTION
- Implementing the **"Parsing and validating request params" mechanism**.
- Introducing and calling the `find-direct-route/4` function that is used _to identify, whether a particular interval between two bus stop points is direct_.
- **Bugfix:** Checking for tuples first, then doing the rest. :smiley:
- Populating sections in **README**: Consuming, Logging, Error handling; adding ToC.
- Bumping version number to **0.2.2**.