### PR TITLE
Bugfix: Compile and build a production release for containerization, not a dev version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #
 # .gitignore
 # =============================================================================
-# Urban bus routing microservice prototype (LFE/OTP port). Version 0.3.0
+# Urban bus routing microservice prototype (LFE/OTP port). Version 0.3.2
 # =============================================================================
 # An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Dockerfile
 # =============================================================================
-# Urban bus routing microservice prototype (LFE/OTP port). Version 0.3.0
+# Urban bus routing microservice prototype (LFE/OTP port). Version 0.3.2
 # =============================================================================
 # An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ COPY       rebar.config bus/
 WORKDIR    bus
 # Setting the HOME env var forcing Rebar3 to create ".cache/rebar3/" locally.
 ENV        HOME=.
-RUN        ["rebar3",        "compile"]
-RUN        ["rebar3", "lfe", "release"]
+RUN        ["rebar3", "as", "prod",        "compile"]
+RUN        ["rebar3", "as", "prod", "lfe", "release"]
 
 # === Stage 2: Run the microservice ===========================================
 FROM       alpine

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile
 # =============================================================================
-# Urban bus routing microservice prototype (LFE/OTP port). Version 0.3.0
+# Urban bus routing microservice prototype (LFE/OTP port). Version 0.3.2
 # =============================================================================
 # An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ $ rebar3 tree
 ===> Fetching pc v1.14.0
 ===> Analyzing applications...
 ...
-└─ bus─0.3.0 (project app)
+└─ bus─0.3.2 (project app)
    ├─ cowboy─2.10.0 (hex package)
    │  ├─ cowlib─2.12.1 (hex package)
    │  └─ ranch─1.8.0 (hex package)

--- a/README.md
+++ b/README.md
@@ -222,11 +222,11 @@ The microservice has the ability to log messages to a logfile and to the Unix sy
 ```
 $ tail -f _build/prod/rel/bus/log/bus.log
 ...
-[2023-07-31|01:20:11.256584+03:00][info]  Server started on port 8765
-[2023-07-31|01:20:11.257210+03:00][info]  Application: bus. Started at: bus@localhost.
-[2023-07-31|01:21:25.207825+03:00][debug]  from=4838 | to=524987
-[2023-07-31|01:21:50.882326+03:00][debug]  from=82 | to=35390
-[2023-07-31|01:25:35.616223+03:00][info]  Server stopped
+[2023-08-03|19:00:23.124525+03:00][info]  Server started on port 8765
+[2023-08-03|19:00:23.124980+03:00][info]  Application: bus. Started at: bus@localhost.
+[2023-08-03|19:01:25.207826+03:00][debug]  from=4838 | to=524987
+[2023-08-03|19:01:50.882327+03:00][debug]  from=82 | to=35390
+[2023-08-03|19:05:05.518063+03:00][info]  Server stopped
 ```
 
 Messages registered by the Unix system logger can be seen and analyzed using the `journalctl` utility:
@@ -234,11 +234,11 @@ Messages registered by the Unix system logger can be seen and analyzed using the
 ```
 $ journalctl -f
 ...
-Jul 31 01:20:10 <hostname> bus[<pid>]: Starting up
-Jul 31 01:20:11 <hostname> bus[<pid>]: Server started on port 8765
-Jul 31 01:21:25 <hostname> bus[<pid>]: from=4838 | to=524987
-Jul 31 01:21:50 <hostname> bus[<pid>]: from=82 | to=35390
-Jul 31 01:25:35 <hostname> bus[<pid>]: Server stopped
+Aug 03 19:00:22 <hostname> bus[<pid>]: Starting up
+Aug 03 19:00:23 <hostname> bus[<pid>]: Server started on port 8765
+Aug 03 19:01:25 <hostname> bus[<pid>]: from=4838 | to=524987
+Aug 03 19:01:50 <hostname> bus[<pid>]: from=82 | to=35390
+Aug 03 19:05:05 <hostname> bus[<pid>]: Server stopped
 ```
 
 ### Error handling

--- a/apps/bus/src/bus-app.lfe
+++ b/apps/bus/src/bus-app.lfe
@@ -1,7 +1,7 @@
 ;
 ; apps/bus/src/bus-app.lfe
 ; =============================================================================
-; Urban bus routing microservice prototype (LFE/OTP port). Version 0.3.0
+; Urban bus routing microservice prototype (LFE/OTP port). Version 0.3.2
 ; =============================================================================
 ; An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 ; as a microservice, implementing a simple urban bus routing prototype.
@@ -12,7 +12,7 @@
 ;
 
 #| ----------------------------------------------------------------------------
- | @version 0.3.0
+ | @version 0.3.2
  | @since   0.0.1
  |#
 (defmodule bus-app

--- a/apps/bus/src/bus-controller.lfe
+++ b/apps/bus/src/bus-controller.lfe
@@ -1,7 +1,7 @@
 ;
 ; apps/bus/src/bus-controller.lfe
 ; =============================================================================
-; Urban bus routing microservice prototype (LFE/OTP port). Version 0.3.0
+; Urban bus routing microservice prototype (LFE/OTP port). Version 0.3.2
 ; =============================================================================
 ; An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 ; as a microservice, implementing a simple urban bus routing prototype.
@@ -12,7 +12,7 @@
 ;
 
 #| ----------------------------------------------------------------------------
- | @version 0.3.0
+ | @version 0.3.2
  | @since   0.0.12
  |#
 (defmodule bus-controller

--- a/apps/bus/src/bus-handler.lfe
+++ b/apps/bus/src/bus-handler.lfe
@@ -1,7 +1,7 @@
 ;
 ; apps/bus/src/bus-handler.lfe
 ; =============================================================================
-; Urban bus routing microservice prototype (LFE/OTP port). Version 0.3.0
+; Urban bus routing microservice prototype (LFE/OTP port). Version 0.3.2
 ; =============================================================================
 ; An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 ; as a microservice, implementing a simple urban bus routing prototype.
@@ -12,7 +12,7 @@
 ;
 
 #| ----------------------------------------------------------------------------
- | @version 0.3.0
+ | @version 0.3.2
  | @since   0.0.13
  |#
 (defmodule bus-handler

--- a/apps/bus/src/bus-helper.lfe
+++ b/apps/bus/src/bus-helper.lfe
@@ -1,7 +1,7 @@
 ;
 ; apps/bus/src/bus-helper.lfe
 ; =============================================================================
-; Urban bus routing microservice prototype (LFE/OTP port). Version 0.3.0
+; Urban bus routing microservice prototype (LFE/OTP port). Version 0.3.2
 ; =============================================================================
 ; An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 ; as a microservice, implementing a simple urban bus routing prototype.
@@ -12,7 +12,7 @@
 ;
 
 #| ----------------------------------------------------------------------------
- | @version 0.3.0
+ | @version 0.3.2
  | @since   0.0.5
  |#
 (defmodule aux

--- a/apps/bus/src/bus-sup.lfe
+++ b/apps/bus/src/bus-sup.lfe
@@ -1,7 +1,7 @@
 ;
 ; apps/bus/src/bus-sup.lfe
 ; =============================================================================
-; Urban bus routing microservice prototype (LFE/OTP port). Version 0.3.0
+; Urban bus routing microservice prototype (LFE/OTP port). Version 0.3.2
 ; =============================================================================
 ; An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 ; as a microservice, implementing a simple urban bus routing prototype.
@@ -12,7 +12,7 @@
 ;
 
 #| ----------------------------------------------------------------------------
- | @version 0.3.0
+ | @version 0.3.2
  | @since   0.0.1
  |#
 (defmodule bus-sup

--- a/apps/bus/src/bus.app.src
+++ b/apps/bus/src/bus.app.src
@@ -1,7 +1,7 @@
 %
 % apps/bus/src/bus.app.src
 % =============================================================================
-% Urban bus routing microservice prototype (LFE/OTP port). Version 0.3.0
+% Urban bus routing microservice prototype (LFE/OTP port). Version 0.3.2
 % =============================================================================
 % An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 % as a microservice, implementing a simple urban bus routing prototype.
@@ -13,7 +13,7 @@
 
 {application, bus, [
     {description,  "Urban bus routing microservice prototype."},
-    {vsn,          "0.3.0"},
+    {vsn,          "0.3.2"},
     {licenses,     ["MIT License"]},
     {links,        []},
     {modules,      []},

--- a/config/sys.config
+++ b/config/sys.config
@@ -1,7 +1,7 @@
 %
 % config/sys.config
 % =============================================================================
-% Urban bus routing microservice prototype (LFE/OTP port). Version 0.3.0
+% Urban bus routing microservice prototype (LFE/OTP port). Version 0.3.2
 % =============================================================================
 % An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 % as a microservice, implementing a simple urban bus routing prototype.

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 %
 % rebar.config
 % =============================================================================
-% Urban bus routing microservice prototype (LFE/OTP port). Version 0.3.0
+% Urban bus routing microservice prototype (LFE/OTP port). Version 0.3.2
 % =============================================================================
 % An LFE (Lisp Flavoured Erlang) application, designed and intended to be run
 % as a microservice, implementing a simple urban bus routing prototype.
@@ -13,7 +13,7 @@
 
 {relx, [
     {release, {
-        bus, "0.3.0"
+        bus, "0.3.2"
     }, [
         bus
     ]},


### PR DESCRIPTION
- Compiling and building a **production release** for containerization, not a _dev version_.
- Bumping version number to **0.3.2**.